### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ To compile it, you will also need the developement headers of these libraries.
 
 To compile:
 
+    automake --add-missing
     autoreconf
     ./configure
     make
@@ -19,9 +20,9 @@ To install (as root):
 
 To run:
 
-    vModSynth
+    vmodsynth
 
-(or `./src/vModSynth` if you didn't install it).
+(or `./src/vmodsynth` if you didn't install it).
 
 For detailed documentation, please refer to manual provided within the `./doc` directory.
 


### PR DESCRIPTION
I have almost no experience with the autotools, but running `automake --add-missing` is what autoreconf suggested when I ran it.

I also fixed some minor things in the README, take a look whether it's what you want.
